### PR TITLE
Controller show all IPs and ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 main.spec
 
 /.idea/
+
+.venv/


### PR DESCRIPTION
```plain
============================
https://127.0.0.1:8888
https://172.25.80.1:8888
https://192.168.137.1:8888
https://192.168.***.***:8888
https://192.168.80.1:8888
https://192.168.84.1:8888
============================
```

显示所有 IP，否则显示出的 IP 是虚拟机虚拟网卡的，不是本机实际 IP。

忽略 `.venv` 方便创建虚拟环境进行调试。